### PR TITLE
Switch sync action to a PR flow

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -27,9 +27,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Merge Upstream `main` 
+      - name: Create and Push Branch 
         run: |          
+          git checkout -b weekly-sync-branch-${{ github.run_id }}
           git merge upstream/main --no-commit
           git reset -- ./.github
           git commit -m "Merge upstream:main"
-          git push
+          git commit --allow-empty -m "Empty commit to open PR"
+          git push --set-upstream origin weekly-sync-branch-${{ github.run_id }}
+
+      - name: Open Pull Request 
+        run: |  
+          gh repo set-default actions/gradle-dependency-submission-action
+          gh pr create -B main -H weekly-sync-branch-${{ github.run_id }} --title 'Sync Fork with Upstream' --body 'Weekly Cron. Created by GitHub Actions.'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sister PR to https://github.com/actions/maven-dependency-submission-action/pull/7.

This organization has branch protection rules where we can't commit directly to the main branch. This switches our update action to create a PR. 