### PR TITLE
Use Gradle Plugin version branch

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -1,31 +1,50 @@
+// buildscript {
+//   def getInputParam = { String name ->
+//       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+//       return System.getProperty(name) ?: System.getenv(envVarName)
+//   }
+//   def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
+//   def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
+//   def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+//   def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.3.2'
+
+//   logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
+//   repositories {
+//     maven {
+//       url = pluginRepositoryUrl
+//       if (pluginRepositoryUsername && pluginRepositoryPassword) {
+//         logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
+//         credentials {
+//           username = pluginRepositoryUsername
+//           password = pluginRepositoryPassword
+//         }
+//         authentication {
+//           basic(BasicAuthentication)
+//         }
+//       }
+//     }
+//   }
+//   dependencies {
+//     classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
+//   }
+// }
+
+// apply plugin: org.gradle.github.GitHubDependencyGraphPlugin
 buildscript {
   def getInputParam = { String name ->
       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
       return System.getProperty(name) ?: System.getenv(envVarName)
   }
-  def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
-  def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
-  def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
-  def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.3.2'
 
-  logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
   repositories {
-    maven { 
-      url = pluginRepositoryUrl
-      if (pluginRepositoryUsername && pluginRepositoryPassword) {
-        logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
-        credentials {
-          username = pluginRepositoryUsername
-          password = pluginRepositoryPassword
-        }
-        authentication {
-          basic(BasicAuthentication)
-        }
-      }
+    maven {
+      url = "https://jitpack.io"
     }
   }
+
   dependencies {
-    classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
+    // Using JitPack to fetch specific commit from GitHub
+    classpath "com.github.gradle:github-dependency-graph-gradle-plugin:20d684b171ef2b27441e7b6fc27af191d49e414f"
   }
 }
 

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -33,7 +33,8 @@ buildscript {
   }
   dependencies {
     // classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
-    classpath "com.github.ljones140.github-dependency-graph-gradle-plugin:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-20d684b171-1"
+    // classpath "com.github.ljones140.github-dependency-graph-gradle-plugin:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-20d684b171-1"
+    classpath "com.github.ljones140:github-dependency-graph-gradle-plugin:20d684b171"
   }
 }
 

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -45,7 +45,7 @@ buildscript {
   dependencies {
     // Using JitPack to fetch specific commit from GitHub
 
-    classpath "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
+    implementation "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
   }
 }
 

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -1,52 +1,64 @@
-// buildscript {
-//   def getInputParam = { String name ->
-//       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-//       return System.getProperty(name) ?: System.getenv(envVarName)
-//   }
-//   def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
-//   def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
-//   def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
-//   def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.3.2'
-
-//   logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
-//   repositories {
-//     maven {
-//       url = pluginRepositoryUrl
-//       if (pluginRepositoryUsername && pluginRepositoryPassword) {
-//         logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
-//         credentials {
-//           username = pluginRepositoryUsername
-//           password = pluginRepositoryPassword
-//         }
-//         authentication {
-//           basic(BasicAuthentication)
-//         }
-//       }
-//     }
-//   }
-//   dependencies {
-//     classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
-//   }
-// }
-
-// apply plugin: org.gradle.github.GitHubDependencyGraphPlugin
 buildscript {
   def getInputParam = { String name ->
       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
       return System.getProperty(name) ?: System.getenv(envVarName)
   }
+  def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
+  def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
+  def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+  def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.3.2'
 
+  logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
   repositories {
     maven {
       url = "https://jitpack.io"
     }
+    maven {
+      url = pluginRepositoryUrl
+      if (pluginRepositoryUsername && pluginRepositoryPassword) {
+        logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
+        credentials {
+          username = pluginRepositoryUsername
+          password = pluginRepositoryPassword
+        }
+        authentication {
+          basic(BasicAuthentication)
+        }
+      }
+    }
+
+    maven {
+      url = "https://jitpack.io"
+    }
   }
-
   dependencies {
-    // Using JitPack to fetch specific commit from GitHub
-
-    implementation "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
+    // classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
+    classpath "com.github.ljones140.github-dependency-graph-gradle-plugin:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-20d684b171-1"
   }
 }
+
+// // apply plugin: org.gradle.github.GitHubDependencyGraphPlugin
+// buildscript {
+//   def getInputParam = { String name ->
+//       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+//       return System.getProperty(name) ?: System.getenv(envVarName)
+//   }
+
+//   repositories {
+//     maven {
+//       url = "https://jitpack.io"
+//     }
+//   maven {
+//       url = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
+//       // Original credential code...
+//     }
+//   }
+
+//   dependencies {
+//     // Using JitPack to fetch specific commit from GitHub
+
+//     implementation "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
+//   }
+// }
 
 apply plugin: org.gradle.github.GitHubDependencyGraphPlugin

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -8,28 +8,11 @@ buildscript {
   def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
   def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.3.2'
 
-  logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
+  logger.lifecycle("Resolving dependency graph plugin")
   repositories {
     maven {
       url = "https://jitpack.io"
     }
-    // maven {
-    //   url = pluginRepositoryUrl
-    //   if (pluginRepositoryUsername && pluginRepositoryPassword) {
-    //     logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
-    //     credentials {
-    //       username = pluginRepositoryUsername
-    //       password = pluginRepositoryPassword
-    //     }
-    //     authentication {
-    //       basic(BasicAuthentication)
-    //     }
-    //   }
-    // }
-
-    // maven {
-    //   url = "https://jitpack.io"
-    // }
   }
   dependencies {
     classpath "com.github.ljones140:github-dependency-graph-gradle-plugin:20d684b171"

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -13,53 +13,27 @@ buildscript {
     maven {
       url = "https://jitpack.io"
     }
-    maven {
-      url = pluginRepositoryUrl
-      if (pluginRepositoryUsername && pluginRepositoryPassword) {
-        logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
-        credentials {
-          username = pluginRepositoryUsername
-          password = pluginRepositoryPassword
-        }
-        authentication {
-          basic(BasicAuthentication)
-        }
-      }
-    }
+    // maven {
+    //   url = pluginRepositoryUrl
+    //   if (pluginRepositoryUsername && pluginRepositoryPassword) {
+    //     logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
+    //     credentials {
+    //       username = pluginRepositoryUsername
+    //       password = pluginRepositoryPassword
+    //     }
+    //     authentication {
+    //       basic(BasicAuthentication)
+    //     }
+    //   }
+    // }
 
-    maven {
-      url = "https://jitpack.io"
-    }
+    // maven {
+    //   url = "https://jitpack.io"
+    // }
   }
   dependencies {
-    // classpath "org.gradle:github-dependency-graph-gradle-plugin:${dependencyGraphPluginVersion}"
-    // classpath "com.github.ljones140.github-dependency-graph-gradle-plugin:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-20d684b171-1"
     classpath "com.github.ljones140:github-dependency-graph-gradle-plugin:20d684b171"
   }
 }
-
-// // apply plugin: org.gradle.github.GitHubDependencyGraphPlugin
-// buildscript {
-//   def getInputParam = { String name ->
-//       def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-//       return System.getProperty(name) ?: System.getenv(envVarName)
-//   }
-
-//   repositories {
-//     maven {
-//       url = "https://jitpack.io"
-//     }
-//   maven {
-//       url = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
-//       // Original credential code...
-//     }
-//   }
-
-//   dependencies {
-//     // Using JitPack to fetch specific commit from GitHub
-
-//     implementation "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
-//   }
-// }
 
 apply plugin: org.gradle.github.GitHubDependencyGraphPlugin

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -44,7 +44,8 @@ buildscript {
 
   dependencies {
     // Using JitPack to fetch specific commit from GitHub
-    classpath "com.github.gradle:github-dependency-graph-gradle-plugin:20d684b171ef2b27441e7b6fc27af191d49e414f"
+
+    classpath "com.github.ljones140:github-dependency-graph-gradle-plugin:dependency-graph-detector-configurable-SNAPSHOT"
   }
 }
 


### PR DESCRIPTION
Issue https://github.com/github/dependency-graph/issues/6261

We have this https://github.com/gradle/github-dependency-graph-gradle-plugin/pull/177 PR open to update the Gradle Plugin this action uses so we can control the detector on the snap shot.

Tested here https://github.com/dsp-testing/ljones-gradle/blob/main/.github/workflows/gradle-auto-submit.yml

This allows us to pass env vars to add attributes to the snapshot. Example below:

```yaml
        uses: actions/gradle-dependency-submission-action/dependency-submission@462057aab6f82a71f3561b9bb1dc916010865f97
        env: 
          GITHUB_DEPENDENCY_GRAPH_REF: "refs/heads/main"
          GITHUB_DEPENDENCY_GRAPH_SHA: "60ee2762457f9abb3bf4ae405ab741093d8b61a7"
          GITHUB_DEPENDENCY_GRAPH_DETECTOR_NAME: "env var detector"
          GITHUB_DEPENDENCY_GRAPH_DETECTOR_VERSION: "456"
          GITHUB_DEPENDENCY_GRAPH_DETECTOR_URL: "https://www.foo.com"
```

I've had to modify the plugin script to use [jitpack](https://jitpack.io/#ljones140/github-dependency-graph-gradle-plugin/dependency-graph-detector-configurable-20d684b171-1) to install the Gradle plugin from the git repo of my branch. 